### PR TITLE
Add the ability to toggle hover labels on and off for specific plots

### DIFF
--- a/graphy.js
+++ b/graphy.js
@@ -259,6 +259,10 @@ var Graphy = {
 
             var toHighlight = []; // array of objects with a plot and point property
             $.each(_plots, function() {
+              // Allows you to turn hover on and off for specific lines
+              if(this.options.hover === false) {
+                return;
+              }
               var plotPoint = this.fromDocumentPixelToPlotPoint({x: e.pageX, y:e.pageY});
 
               // values are in-order along x-axis in this.data, so find closest point to cursor with simple binary search

--- a/require-graphy.js
+++ b/require-graphy.js
@@ -274,6 +274,10 @@ var Graphy = {
 
             var toHighlight = []; // array of objects with a plot and point property
             $.each(_plots, function() {
+              // Allows you to turn hover on and off for specific lines
+              if(this.options.hover === false) {
+                return;
+              }
               var plotPoint = this.fromDocumentPixelToPlotPoint({x: e.pageX, y:e.pageY});
 
               // values are in-order along x-axis in this.data, so find closest point to cursor with simple binary search

--- a/source/graphy.core.js
+++ b/source/graphy.core.js
@@ -259,6 +259,10 @@ var Graphy = {
 
             var toHighlight = []; // array of objects with a plot and point property
             $.each(_plots, function() {
+              // Allows you to turn hover on and off for specific lines
+              if(this.options.hover === false) {
+                return;
+              }
               var plotPoint = this.fromDocumentPixelToPlotPoint({x: e.pageX, y:e.pageY});
 
               // values are in-order along x-axis in this.data, so find closest point to cursor with simple binary search


### PR DESCRIPTION
This adds a `hover` option to each plot object that allows you to turn the hover label on or off for a specific plot.  `hover` is a `Boolean` toggle.
